### PR TITLE
fix: remove console.log

### DIFF
--- a/index.js
+++ b/index.js
@@ -207,7 +207,8 @@ class Analytics {
                 return Promise.resolve(batchData);
             })
             .catch(err => {
-                console.log('Error in sending events:', err);
+                // DO not log just throw error
+                // console.log('Error in sending events:', err);
                 if (err.response) {
                     const error = new Error(err.response.statusText);
                     finish(error);


### PR DESCRIPTION
# Summary:
remove `console.log` for logging errors and let the final user handle the errors instead.