### PR TITLE
[GEN-2290] Remove AWS API Gateway

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,8 +28,8 @@ class Analytics {
         assert(apiKey, 'Please provide a valid API key.');
 
         this.defaultHost = (env == 'production')
-            ? 'https://api.mable.ai/v1/batch'
-            : 'https://api.mable.ai/dev/v1/batch';
+            ? 'https://ingestion.mable.ai/batch'
+            : 'https://ingestion.dev.mable.ai/batch';
 
         this.apiKey = apiKey;
         this.host = host || this.defaultHost;


### PR DESCRIPTION
(Situation) Currently the [api.mable.ai/v1/batch](http://api.mable.ai/v1/batch) api gateway acts only as a proxy that forwards the request to [https://ingestion.mable.ai/batch](https://ingestion.dev.mable.ai/batch). 

This is a problem because this proxy is unasked for and is increasing the AWS costs.

(Expected Outcome) After this ticket is done, the API gateway will be deleted and the endpoint is changed where ever necessary.

## Acceptance Criteria
- [x] All endpoints utilising this gateway is replaced.

- [ ] Repos using analytics package are version bumped.
- [x] MSS endpoints also needs to be updated (see constants file). https://github.com/Mable-AI/mable-source-service/pull/10